### PR TITLE
Fix opencv variables for ubuntu 16.04 and open 2.4.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(iarc7_vision)
 
+set("OpenCV_DIR" "/usr/local/share/OpenCV")
+set(CUDA_USE_STATIC_CUDA_RUNTIME OFF CACHE "" INTERNAL)
+
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
This still builds on travis and fixes compatibility issues with Ubuntu 16.04 which is our support target. I'd like to also do this for our version of vision_opencv