### PR TITLE
Add parameters for crazyflie

### DIFF
--- a/param/line_detector_params_crazyflie.yaml
+++ b/param/line_detector_params_crazyflie.yaml
@@ -1,0 +1,11 @@
+# Settings for the image processing portion of the GridLineEstimator
+line_extractor:
+    # Pixels per meter to scale image to
+    pixels_per_meter: 250
+    canny_high_threshold: 20000.0
+    canny_threshold_ratio: 3
+    canny_sobel_size: 7
+    hough_rho_resolution: 1.0
+    hough_theta_resolution: 0.02
+    hough_thresh_fraction: 0.35
+    fov: 1.07

--- a/param/optical_flow_params_crazyflie.yaml
+++ b/param/optical_flow_params_crazyflie.yaml
@@ -1,0 +1,71 @@
+# Settings for the optical flow estimator
+optical_flow_estimator:
+    # fov of the camera
+    fov: 1.07
+
+    # Minimum altitude to run the detector
+    min_estimation_altitude: 0.3
+
+    # Camera vertical threshold
+    # Maximum angle between camera forward vector and down vector
+    # required for optical flow to run
+    camera_vertical_threshold: 0.3
+
+    # Window size for optical flow
+    win_size: 20
+
+    # Levels of the pyramid to run the optical flow at
+    max_level: 3
+
+    # Number of iterations to run the optical flow
+    iters: 20
+
+    # Number of points to track
+    points: 100
+
+    # Quality level for the corner detector
+    quality_level: 0.01
+
+    # Min distance between points for the corner detector
+    min_dist: 20
+
+    # Image scale factor
+    scale_factor: 0.5
+
+    ###############################
+    ########## DEBUGGING ##########
+    ###############################
+
+    # Publish image with average velocity vector drawn on it
+    debug_average_vector_image: true
+
+    # Publish lots of intermediate velocity calculations
+    debug_intermediate_velocities: false
+
+    # Publish the orientation used by the optical flow estimator
+    debug_orientation: true
+
+    # Print out times when things are received/processed
+    debug_times: false
+
+    # Debug settings for the optical flow estimator
+    # Publish image with the velocity vectors drawn on it
+    debug_vectors_image: true
+
+    ################################
+
+    # Min variance to send with velocity measurements
+    variance: 1.0
+
+    # What to scale the variance on according to the rotation rate
+    variance_scale: 0.19 # 0.3s/90deg
+
+    # Cutoff area where velocity vectors aren't included in the average
+    x_cutoff_region_velocity_measurement: 0.2
+    y_cutoff_region_velocity_measurement: 0.2
+
+    # Frames to skip before publishing debug images
+    debug_frameskip: 6
+
+    # Timeout for updates from tf
+    tf_timeout: 1.0

--- a/param/vision_node_params_crazyflie.yaml
+++ b/param/vision_node_params_crazyflie.yaml
@@ -1,0 +1,56 @@
+startup_timeout: 10.0
+
+# Message queue item limit
+message_queue_item_limit: 3
+
+# Settings for the grid position estimation portion of the GridLineEstimator
+grid_estimator:
+    # Step size for initial orientation sweep
+    theta_step: 0.004
+
+    # Step size for initial translation sweep
+    grid_step: 0.01
+
+    # Distance between the center of one gridline and the center of the next
+    grid_spacing: 0.229
+
+    # Thickness of each gridline
+    grid_line_thickness: 0.038
+
+    # (x-location of gridline intersection) - (x-location of origin)
+    grid_zero_offset_x: 0.5
+
+    # (y-location of gridline intersection) - (y-location of origin)
+    grid_zero_offset_y: 0.5
+
+    # Number of times to iterate in get1dGridShift
+    grid_translation_mean_iterations: 1
+
+    # Threshold to reject lines that aren't aligned with the grid
+    line_rejection_angle_threshold: 0.262 # pi/12
+
+    # Minimum altitude to run the detector
+    min_extraction_altitude: 0.1
+
+    # Allowed lag between available position and frame timestamp
+    allowed_position_stamp_error: 0.1
+
+grid_line_estimator:
+    # Should we forgo line counting and just detect lines on the ground?
+    debug_line_detector: false
+
+    # Should we spit out a marker vector for the quad's estimated orientation?
+    debug_direction: false
+
+    # Should we spit out an edge image for each frame on the `edges` topic?
+    debug_edges: true
+
+    # Should we spit out a copy of the input with lines drawn on top on the
+    # `lines` topic?
+    debug_lines: true
+
+    # Should we spit out markers for the transformed lines?
+    debug_line_markers: true
+
+    # Uncomment this to override the height from robot_localization
+    # debug_height: 0.22


### PR DESCRIPTION
This may seem weird, but my idea is to use mixed virtual and real processing at the same time. So we can use a simulated camera to do image processing and fuse that with what the crazyflie is doing at the same time. Should allow all sorts of things to be tested.

The parameters are just a copy from V1.1